### PR TITLE
Disable all text boxes in the users section

### DIFF
--- a/static/js/disable.js
+++ b/static/js/disable.js
@@ -1,5 +1,5 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$; // use jQuery
 
 exports.postAceInit = function (hook_name, args, cb) {
-  $('#myusernameedit').prop('disabled', true); // disable the input box
+  $('#users input[type=text]').prop('disabled', true); // disable the text boxes in the users section.
 }


### PR DESCRIPTION
The plugin currently disables the current user's text box field to prevent from setting their name, but it does not disable the text boxes for any collaborators in the pad. This means the current user can change the names of other users, while the other users can't change it back. This branch disables all the text boxes in the users section to prevent that from happening.